### PR TITLE
xephyr_selenium: Add helper script to run `selenium` in Xephyr

### DIFF
--- a/xephyr_selenium
+++ b/xephyr_selenium
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+here="$(dirname "$0")"
+
+xephyr_pid=""
+cleanup() {
+   if [[ -n "$xephyr_pid" ]]
+   then
+      kill "$xephyr_pid"
+   fi
+}
+
+trap cleanup EXIT
+
+findDisplayNumber() {
+   #Based on https://superuser.com/a/127344
+   # local i=1
+   # while [ -f /tmp/.X$i-lock ]
+   # do
+   #    i=$(($i + 1))
+   # done
+   # echo $i
+
+   # Hack, because it seems like the above isn't a thing anymore:
+   echo $(($RANDOM + 1))
+}
+
+displayNumber=":$(findDisplayNumber)"
+echo "Starting Xephyr on $displayNumber"
+Xephyr -resizeable "$displayNumber" &
+xephyr_pid="$!"
+export DISPLAY="$displayNumber"
+"$here/selenium"


### PR DESCRIPTION
This is handy on Linux for avoiding windows popping up everywhere when trying to run local Chrome tests. Xephyr keeps them all boxed within a single confining window.

I've manually set it up for a while; this provides an easy-to-use script for anyone else who wants to.

![image](https://user-images.githubusercontent.com/1283490/162540782-08aa345e-d5a6-460a-a566-32f9cce84f70.png)

cr_req 1
This is dev-only

## QA instructions
0. Make sure you have `Xephyr` installed: `sudo apt install xserver-xephyr` on Ubuntu.
1. On your local system, run the `xephyr_selenium` script from this PR, just like you would normally have run the `selenium` script when running tests locally (see Overlord for docs if needed). A window with the name `Xephyr` should pop up.
2. Run a test using your local Selenium server (i.e., with `host=local`). You should see the Chrome window pop up inside the `Xephyr` window, which you can move around as you please.