### PR TITLE
Update `get_selenium.sh` to use new Chrome for Testing URLs

### DIFF
--- a/get_selenium.sh
+++ b/get_selenium.sh
@@ -24,4 +24,5 @@ zipfile="$(basename "$file_name")"
 curl -o "$zipfile" "$chromedriver_url"
 
 unzip $(basename $file_name .zip)
+mv chromedriver-*/chromedriver .
 rm -f "$zipfile"

--- a/get_selenium.sh
+++ b/get_selenium.sh
@@ -7,19 +7,21 @@ extract_version() {
 if [ $(uname -s) = "Linux" ]
 then
    chrome_path=google-chrome
-   file_name=chromedriver_linux64.zip
+   file_name=linux64/chromedriver-linux64.zip
 else
    chrome_path=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
-   file_name=chromedriver_mac64.zip
+   file_name=mac-x64/chromedriver-mac-x64.zip
 fi
 
 chrome_version=$("$chrome_path" --version 2>&1 | extract_version)
 curl --remote-name https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
-chrome_driver_version=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chrome_version")
-chromedriver_url="https://chromedriver.storage.googleapis.com/$chrome_driver_version/$file_name"
+chrome_driver_version=$(curl "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$chrome_version")
+echo $chrome_driver_version
+chromedriver_url="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$chrome_driver_version/$file_name"
 
 echo "$chromedriver_url"
-curl -o "$file_name" "$chromedriver_url"
+zipfile="$(basename "$file_name")"
+curl -o "$zipfile" "$chromedriver_url"
 
 unzip $(basename $file_name .zip)
-rm -f $file_name
+rm -f "$zipfile"


### PR DESCRIPTION
Does what it says on the tin. See https://googlechromelabs.github.io/chrome-for-testing/ and https://github.com/GoogleChromeLabs/chrome-for-testing for more information.

qa_req 0
If this works for me, I think it's good enough.
